### PR TITLE
1ページ単位のModifierを指定可能にする

### DIFF
--- a/app/src/main/java/com/rizzi/composepdf/MainActivity.kt
+++ b/app/src/main/java/com/rizzi/composepdf/MainActivity.kt
@@ -222,7 +222,9 @@ class MainActivity : ComponentActivity() {
                 state = pdfState,
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(color = Color.Gray)
+                    .background(color = Color.Gray),
+                contentModifier = Modifier.padding(8.dp)
+
             )
             Column(
                 modifier = Modifier.fillMaxWidth()
@@ -296,7 +298,8 @@ class MainActivity : ComponentActivity() {
                 state = pdfState,
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(color = Color.Gray)
+                    .background(color = Color.Gray),
+                contentModifier = Modifier
             )
             Column(
                 modifier = Modifier.fillMaxWidth()

--- a/bouquet/src/main/java/com/rizzi/bouquet/Bouquet.kt
+++ b/bouquet/src/main/java/com/rizzi/bouquet/Bouquet.kt
@@ -42,7 +42,8 @@ import java.io.IOException
 @Composable
 fun VerticalPDFReader(
     state: VerticalPdfReaderState,
-    modifier: Modifier
+    modifier: Modifier,
+    contentModifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(
         modifier = modifier,
@@ -83,6 +84,7 @@ fun VerticalPDFReader(
                     when (pageContent) {
                         is PageContentInt.PageContent -> {
                             PdfImage(
+                                modifier = contentModifier,
                                 bitmap = { pageContent.bitmap.asImageBitmap() },
                                 contentDescription = pageContent.contentDescription
                             )
@@ -109,7 +111,8 @@ fun Int.dp(): Dp {
 @Composable
 fun HorizontalPDFReader(
     state: HorizontalPdfReaderState,
-    modifier: Modifier
+    modifier: Modifier,
+    contentModifier: Modifier
 ) {
     BoxWithConstraints(
         modifier = modifier,
@@ -149,6 +152,7 @@ fun HorizontalPDFReader(
                 when (pageContent) {
                     is PageContentInt.PageContent -> {
                         PdfImage(
+                            modifier = contentModifier,
                             bitmap = { pageContent.bitmap.asImageBitmap() },
                             contentDescription = pageContent.contentDescription
                         )

--- a/bouquet/src/main/java/com/rizzi/bouquet/PDFImage.kt
+++ b/bouquet/src/main/java/com/rizzi/bouquet/PDFImage.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.layout.ContentScale
 
 @Composable
 internal fun PdfImage(
+    modifier: Modifier = Modifier,
     bitmap: () -> ImageBitmap,
     contentDescription: String = "",
 ) {
@@ -16,6 +17,6 @@ internal fun PdfImage(
         bitmap = bitmap(),
         contentDescription = contentDescription,
         contentScale = ContentScale.FillWidth,
-        modifier = Modifier.fillMaxWidth()
+        modifier = modifier.fillMaxWidth()
     )
 }


### PR DESCRIPTION
利用する画面からcontentModifierとしてページに適用するModifierを指定可能にします。
![Screenshot_1739341104](https://github.com/user-attachments/assets/56ac4071-7f9d-4a07-99af-2c833dcbc1bc)
