### PR TITLE
Lintエラーを無視する

### DIFF
--- a/bouquet/build.gradle.kts
+++ b/bouquet/build.gradle.kts
@@ -40,6 +40,10 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion = "1.4.2"
     }
+    lint{
+        //  Unexpected failure during lint analysis (this is a bug in lint or one of the libraries it depends on)
+        disable += "MutableCollectionMutableState"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
下記のエラーを無視します

> Execution failed for task ':bouquet:bouquet:lintAnalyzeDebug'.
> > A failure occurred while executing com.android.build.gradle.internal.lint.AndroidLintWorkAction
>    > Unexpected failure during lint analysis (this is a bug in lint or one of the libraries it depends on)
>      
>      Message: Unexpected failure during lint analysis (this is a bug in lint or one of the libraries it depends on)
>      
>      Message: Unexpected failure during lint analysis of PdfReaderState.kt (this is a bug in lint or one of the libraries it depends on)
>      
>      Message: Cannot invoke "org.jetbrains.uast.kotlin.KotlinUastResolveProviderService.getBindingContext(org.jetbrains.kotlin.psi.KtElement)" because "service" is null
>      
>      The crash seems to involve the detector \\\`androidx.compose.runtime.lint.MutableCollectionMutableStateDetector\\\`.
>      You can try disabling it with something like this:
>          android {
>              lint {
>                  disable "MutableCollectionMutableState"
>              }
>          }