### PR TITLE
ズーム禁止のときはスクロールも不可にする

### DIFF
--- a/bouquet/src/main/java/com/rizzi/bouquet/Bouquet.kt
+++ b/bouquet/src/main/java/com/rizzi/bouquet/Bouquet.kt
@@ -80,9 +80,16 @@ fun VerticalPDFReader(
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
-                    .tapToZoomVertical(state, constraints),
+                    .let {
+                        if(state.isZoomEnable){
+                            it.tapToZoomVertical(state, constraints)
+                        }else{
+                            it
+                        }
+                    },
                 horizontalAlignment = Alignment.CenterHorizontally,
-                state = lazyState
+                state = lazyState,
+                userScrollEnabled = state.isZoomEnable
             ) {
                 items(pdf.pageCount) {
                     val pageContent = pdf.pageLists[it].stateFlow.collectAsState().value


### PR DESCRIPTION
ジェスチャー操作を禁止し、クリックイベントが発生するようにします。